### PR TITLE
Drop xattrs and allow for more hands-on with keywords

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"github.com/itxaka/luet-mtree/pkg/action"
 	"github.com/itxaka/luet-mtree/pkg/log"
 	"github.com/spf13/cobra"
@@ -27,6 +28,7 @@ import (
 func newGenerateCmd() *cobra.Command {
 	var outputFile string
 	var keywords []string
+	var overrideKeywords []string
 
 	cmd := &cobra.Command{
 		Use:   "generate [file or dir]",
@@ -36,7 +38,12 @@ func newGenerateCmd() *cobra.Command {
 				_ = cmd.Usage()
 				return nil
 			}
-			generateAction := action.NewGenerateAction(args[0], outputFile, keywords)
+
+			if len(keywords) > 0 && len(overrideKeywords) > 0 {
+				log.Log("Cannot use both -k and -K flags. Either add keywords or override the default ones.")
+				return errors.New("cannot use both -k and -K flags. Either add keywords or override the default ones")
+			}
+			generateAction := action.NewGenerateAction(args[0], outputFile, keywords, overrideKeywords)
 			err := generateAction.Run()
 			if err != nil {
 				log.Log(err.Error())
@@ -48,6 +55,7 @@ func newGenerateCmd() *cobra.Command {
 	}
 	f := cmd.Flags()
 	f.StringVarP(&outputFile, "output", "o", "", "Name for output file, otherwise it defaults to stdout")
-	f.StringSliceVarP(&keywords, "keywords", "k", []string{}, "Keywords to use to generate the tree (sha256 will automatically be added)")
+	f.StringSliceVarP(&keywords, "keywords", "k", []string{}, "Add keywords to default ones (type, sha512digest)")
+	f.StringSliceVarP(&overrideKeywords, "overridekeywords", "K", []string{}, "Override the default keyworkds (type, sha512digest)")
 	return cmd
 }

--- a/pkg/action/generate.go
+++ b/pkg/action/generate.go
@@ -27,10 +27,11 @@ type generateAction struct {
 	target     string
 	outputFile string
 	keywords   []string
+	overrideKeywords   []string
 }
 
-func NewGenerateAction(t string, o string, k []string) *generateAction {
-	return &generateAction{target: t, outputFile: o, keywords: k}
+func NewGenerateAction(t string, o string, k []string, K []string) *generateAction {
+	return &generateAction{target: t, outputFile: o, keywords: k, overrideKeywords: K}
 }
 
 func (action generateAction) Run() error {
@@ -53,12 +54,21 @@ func (action generateAction) Run() error {
 	// TODO(itxaka) we may be able to use tar_time ?
 	currentKeywords := []mtree.Keyword{
 		"type",
-		"xattrs",
 		"sha512digest",
 	}
 
 	if len(action.keywords) > 0 {
 		for _, k := range action.keywords {
+			if !mtree.InKeywordSlice(mtree.Keyword(k), currentKeywords) {
+				currentKeywords = append(currentKeywords, mtree.Keyword(k))
+			}
+		}
+	}
+
+	if len(action.overrideKeywords) > 0 {
+		// Empty current keywords as we want to override them
+		currentKeywords = []mtree.Keyword{}
+		for _, k := range action.overrideKeywords {
 			if !mtree.InKeywordSlice(mtree.Keyword(k), currentKeywords) {
 				currentKeywords = append(currentKeywords, mtree.Keyword(k))
 			}

--- a/pkg/action/generate_test.go
+++ b/pkg/action/generate_test.go
@@ -1,0 +1,72 @@
+package action
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/vbatts/go-mtree"
+	"testing"
+)
+
+
+
+func TestGenerateExpandKeywords(t *testing.T) {
+	output := captureOutputAndParse(t, func() {
+		action := NewGenerateAction("testdata/checkfiles/", "", []string{"size"}, make([]string, 0))
+		err := action.Run()
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	assert.Contains(t, output.getRealKeywords(), mtree.Keyword("size"))
+	assert.Contains(t, output.getRealKeywords(), mtree.Keyword("sha512digest"))  // We add this as default
+	assert.Contains(t, output.getRealKeywords(), mtree.Keyword("type"))  // We add this as default
+	assert.NotContains(t, output.getRealKeywords(), mtree.Keyword("uid"))
+	assert.NotContains(t, output.getRealKeywords(), mtree.Keyword("gid"))
+
+	output = captureOutputAndParse(t, func() {
+		action := NewGenerateAction("testdata/checkfiles/", "", []string{"size", "mode"}, make([]string, 0))
+		err := action.Run()
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	assert.Contains(t, output.getRealKeywords(), mtree.Keyword("size"))
+	assert.Contains(t, output.getRealKeywords(), mtree.Keyword("mode"))
+	assert.Contains(t, output.getRealKeywords(), mtree.Keyword("sha512digest"))  // We add this as default
+	assert.Contains(t, output.getRealKeywords(), mtree.Keyword("type"))  // We add this as default
+	assert.NotContains(t, output.getRealKeywords(), mtree.Keyword("uid"))
+	assert.NotContains(t, output.getRealKeywords(), mtree.Keyword("gid"))
+}
+
+func TestGenerateOverrideKeywords(t *testing.T) {
+	output := captureOutputAndParse(t, func() {
+		action := NewGenerateAction("testdata/checkfiles/", "", []string{}, []string{"size"})
+		err := action.Run()
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	assert.Contains(t, output.getRealKeywords(), mtree.Keyword("size"))
+	assert.NotContains(t, output.getRealKeywords(), mtree.Keyword("sha512digest"))
+	assert.NotContains(t, output.getRealKeywords(), mtree.Keyword("type"))
+	assert.NotContains(t, output.getRealKeywords(), mtree.Keyword("uid"))
+	assert.NotContains(t, output.getRealKeywords(), mtree.Keyword("gid"))
+
+	output = captureOutputAndParse(t, func() {
+		action := NewGenerateAction("testdata/checkfiles/", "", []string{}, []string{"size", "mode"})
+		err := action.Run()
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	assert.Contains(t, output.getRealKeywords(), mtree.Keyword("size"))
+	assert.Contains(t, output.getRealKeywords(), mtree.Keyword("mode"))
+	assert.NotContains(t, output.getRealKeywords(), mtree.Keyword("sha512digest"))
+	assert.NotContains(t, output.getRealKeywords(), mtree.Keyword("type"))
+	assert.NotContains(t, output.getRealKeywords(), mtree.Keyword("uid"))
+	assert.NotContains(t, output.getRealKeywords(), mtree.Keyword("gid"))
+}
+

--- a/pkg/action/helpers_test.go
+++ b/pkg/action/helpers_test.go
@@ -1,0 +1,70 @@
+package action
+
+import (
+	"bytes"
+	"github.com/vbatts/go-mtree"
+	"os"
+	"testing"
+)
+
+// captureOutputAndParse hijacks stdout and uses that output to try to return an
+// mtree.DirectoryHierarchy
+// This allows us to parse the mtree output from generate so we can easily parse keywords used for example
+func captureOutputAndParse(t *testing.T, f func())  CustomDirectoryHierarchy {
+	// Overwrite stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	origStdout := os.Stdout
+	os.Stdout = w
+	// Call function
+	f()
+	// Store the output
+	buf := make([]byte, 2048)
+	n, err := r.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Restore stdout
+	os.Stdout = origStdout
+
+	// Parse output
+	res := bytes.NewReader(buf[:n])
+	directoryHierarchy, err := mtree.ParseSpec(res)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cdh := CustomDirectoryHierarchy{directoryHierarchy}
+
+	return cdh
+}
+
+type CustomDirectoryHierarchy struct {
+	*mtree.DirectoryHierarchy
+}
+
+// getRealKeywords gets the "real" keywords used to generate the file
+// The current method from mtree checks for the /set values and those add extra default keywords in them
+// for example uid and gid
+// They are not used to check the mtree values, as those are not stored on the mtree output but its kind of
+// confusing that those are not the real keywords used for the actual files so we add this simple method
+// So we can check them safely in testing
+func (cdh CustomDirectoryHierarchy) getRealKeywords() []mtree.Keyword {
+	var usedkeywords []mtree.Keyword
+	for _, e := range cdh.Entries {
+		switch e.Type {
+		case mtree.FullType, mtree.RelativeType:
+			if e.Type != mtree.SpecialType {
+				kvs := e.Keywords
+				for _, kv := range kvs {
+					kw := kv.Keyword()
+					if !mtree.InKeywordSlice(kw, usedkeywords) {
+						usedkeywords = append(usedkeywords, mtree.KeywordSynonym(string(kw)))
+					}
+				}
+			}
+		}
+	}
+	return usedkeywords
+}


### PR DESCRIPTION
Drop teh default xattrs from the generation as this has probed
troublesome when working with docker, as it doesnt keep some file
capabilities so the mtree checks never succedes.

Also adds a new option -K to override the keyword list. This will allow
us to control the keywords used in the future as it allows us not only
to expand the default keywords (sha512digest and type) but also to fully
override the list of keywords via command line instead of having to
modify the code to add those.

The default ones left in the code are the basic ones that we need, if
something needs to drop those, then the mtree check is utterly useless.

Signed-off-by: Itxaka <igarcia@suse.com>