### PR TITLE
Fix exclude for oem dir

### DIFF
--- a/pkg/action/unpack.go
+++ b/pkg/action/unpack.go
@@ -20,7 +20,7 @@ type YamlMtree struct {
 }
 
 // excludes is a list of dirs that are excluded from the mtree check, usually those that are modified
-var excludes = []string{"var/cache/luet", "oem/", "usr/local/", "lost+found", "tmp/", "mnt/"}
+var excludes = []string{"var/cache/luet", "oem", "usr/local/", "lost+found", "tmp/", "mnt/"}
 
 func UnpackAndMtree(image string, destination string) (map[string]string, error) {
 	// Create temp dir for extracting the metadata


### PR DESCRIPTION
If the dir is empty, the entry to check will be set to `oem` with no
slash, so its not excluded properly

Signed-off-by: Itxaka <igarcia@suse.com>